### PR TITLE
Revert "use sealed abstract class"

### DIFF
--- a/src/main/scala/knockoff/MarkdownParsing.scala
+++ b/src/main/scala/knockoff/MarkdownParsing.scala
@@ -326,7 +326,7 @@ we've grabbed the spanning elements of each block, to construct the final
 
 import scala.collection.mutable.ListBuffer
 
-sealed abstract class Chunk extends Product with Serializable {
+trait Chunk {
   def content: String
 
   def isLinkDefinition = false


### PR DESCRIPTION
This reverts commit 2c256bb0212d296cc310820ac8f18f4ef34bacaa.

https://github.com/foundweekends/pamflet/pull/80#issuecomment-270522834