### PR TITLE
Fix img tag generation

### DIFF
--- a/shared/src/main/scala/knockoff/XHTMLWriter.scala
+++ b/shared/src/main/scala/knockoff/XHTMLWriter.scala
@@ -128,7 +128,7 @@ trait XHTMLWriter {
 
   def imageLinkToXHTML : ( collection.Seq[Span], String, Option[String] ) => Node = {
     ( spans, url, title ) => <img src={ url } title={ title.getOrElse(null) }
-                                     alt={ spans.map( spanToXHTML(_) ) } ></img>
+                                     alt={ spans.map( spanToXHTML(_) ) } />
   }
 
   def escapeURL( url : String ) : Node = {


### PR DESCRIPTION
This PR removes `img` closing tag; see https://www.w3schools.com/tags/tag_img.asp
I noticed that since the W3 validator complains about this tag: 

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/4929546/93046131-11bd5680-f627-11ea-88b6-05e545b405fa.png">
