### PR TITLE
Fix warning. use temurin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/setup-java@v5
       with:
         java-version: ${{matrix.java}}
-        distribution: adopt
+        distribution: temurin
     - uses: actions/checkout@v7
     - uses: coursier/cache-action@v8
     - uses: sbt/setup-sbt@v1


### PR DESCRIPTION
> Notice: AdoptOpenJDK has moved to Eclipse Temurin https://github.com/actions/setup-java#supported-distributions please consider changing to the 'temurin' distribution type in your setup-java configuration.